### PR TITLE
Update pyyaml version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ virtualenv
 
 # Vagrant
 .vagrant
+
+# Editors
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
-python:
-  - "2.7"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:
   include:
+    - python: 2.7
+      dist: xenial
     - python: 3.7
       dist: xenial
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.7"
 install:
   - "pip install -r requirements.txt"
   - "pip install -r test-requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.7"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: python
 python:
   - "2.7"
   - "3.7"
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - "pip install -r requirements.txt"
   - "pip install -r test-requirements.txt"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools
 wheel==0.24.0
 Click==6.2
-PyYAML==3.11
+PyYAML==3.13

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -29,7 +29,7 @@ run_pep8_check(){
 }
 
 run_unit_tests(){
-    OMIT="/usr/*,*travis*"
+    OMIT="/usr/*,*venv*,*travis*"
     if [ -n "$testargs" ]; then
         # pytest -s => show std output (i.e print statements)
         coverage run --omit=$OMIT -m pytest -s "$testargs"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
     install_requires=[
         'Click==6.2',
-        'PyYAML==3.11'
+        'PyYAML==3.13'
     ],
     keywords='yamlpal yaml',
     author='Joris Roovers',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,6 @@
-discover==0.4.0 # support for python 2.6
-unittest2==1.1.0 # support for python 2.6
-flake8==2.4.0
-coverage==3.7.1
-python-coveralls==2.5.0
+flake8==3.7.8
+coverage==4.5.3
+python-coveralls==2.9.2
 radon==1.2.1
-mock==1.3.0
-pytest==2.8.2
+mock==3.0.5
+pytest==5.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,4 @@ coverage==4.5.3
 python-coveralls==2.9.2
 radon==1.2.1
 mock==3.0.5
-pytest==5.0.1
+pytest==4.6.4

--- a/yamlpal/cli.py
+++ b/yamlpal/cli.py
@@ -81,8 +81,8 @@ def get_str_content(str_value):
 @click.argument('yamlpath')
 @click.argument('newcontent')
 @click.option('-f', '--file', type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
-              multiple=True, help="File to insert new content in. Can by specified multiple times to modify " +
-                                  "multiple files. Files are not modified inline by default. " +
+              multiple=True, help="File to insert new content in. Can by specified multiple times to modify "
+                                  "multiple files. Files are not modified inline by default. "
                                   "You can also provide (additional) file paths via stdin.")
 @click.option('-i', '--inline', help="Edit file inline instead of dumping it to std out.", is_flag=True)
 def insert(yamlpath, newcontent, file, inline):
@@ -98,8 +98,8 @@ def insert(yamlpath, newcontent, file, inline):
 @click.argument('yamlpath')
 @click.option('-f', '--file', type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
               help="File to find content in.")
-@click.option('-F', '--format', help="Format string in which matched content should be returned. " +
-                                     "See the section 'Format Strings' below for details on format strings. " +
+@click.option('-F', '--format', help="Format string in which matched content should be returned. "
+                                     "See the section 'Format Strings' below for details on format strings. "
                                      "(default format depends on what is printed)",
               default=dumper.AUTODETERMINE_FORMAT)
 def find(yamlpath, file, format):
@@ -178,7 +178,7 @@ def find_element(yaml_dict, search_str):
     parsed_parts = []
 
     for dict_part in dict_parts:
-        matches = re.match("(.*)(\[([0-9]+)\])", dict_part)
+        matches = re.match(r"(.*)(\[([0-9]+)\])", dict_part)
         if matches:
             list_name = matches.groups()[0]
             list_index = int(matches.groups()[2])

--- a/yamlpal/tests/test_find.py
+++ b/yamlpal/tests/test_find.py
@@ -94,7 +94,7 @@ class FindTests(BaseTestCase):
             'total': "30-30\n",
             'comments': "31-34\n",  # TODO(jroovers): we don't correctly parse text that starts with > yet
         }
-        for query, expected in query_result_mapping.iteritems():
+        for query, expected in query_result_mapping.items():
             # Test line numbers
             result = self.cli.invoke(cli.cli, ["find", query, "-F", "%{linenr}-%{linenr.end}\n",
                                                "-f", self.get_sample_path("sample1")])


### PR DESCRIPTION
I had an issue installing on MacOS, because of the older PyYAML version being used. PyYAML 3.13 installed without issues, and all the tests for yamlpal also passed with this version.

Since I was here, I also updated all the test dependencies, because the older pytest version was having issues with a new Python 3.7 behavior (details in the commit). I also removed some dependencies meant for Python 2.6, and added Python 3.7 to the Travis config file.